### PR TITLE
Pull request adding OneDrive support for "recent" and "shortcut" folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-native-file-picker
+# GEOENGINEERS CUSTOMIZED - react-native-file-picker
 A React Native module that allows you to use native UI to select a file from the device library
 Based on [react-native-image-picker](https://github.com/marcshilling/react-native-image-picker)
 

--- a/android/src/main/java/com/filepicker/FilePickerModule.java
+++ b/android/src/main/java/com/filepicker/FilePickerModule.java
@@ -255,8 +255,11 @@ public class FilePickerModule extends ReactContextBaseJavaModule implements Acti
 
         final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
+        if (isExternalSkydriveResourceUri(uri)) {
+            //DONT DO ANYTHING?  THIS RETURNS THE PATH AS IS FOR ONEDRIVE
+        } 
         // DocumentProvider
-        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+        else if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
 
             // ExternalStorageProvider
             if (isExternalStorageDocument(uri)) {

--- a/android/src/main/java/com/filepicker/FilePickerModule.java
+++ b/android/src/main/java/com/filepicker/FilePickerModule.java
@@ -280,8 +280,12 @@ public class FilePickerModule extends ReactContextBaseJavaModule implements Acti
                     return split[1];
                 } else {
                     String prefix = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ? "file:///" : "content://";
+                    String contentId = split[0];
+                    if(split.length > 1){
+                        contentId = split[1];
+                    }
                     final Uri contentUri = ContentUris.withAppendedId(
-                            Uri.parse(prefix + "downloads/public_downloads"), Long.valueOf(split[1]));
+                            Uri.parse(prefix + "downloads/public_downloads"), Long.valueOf(contentId));
 
                     return getDataColumn(context, contentUri, null, null);
                 }

--- a/android/src/main/java/com/filepicker/FilePickerModule.java
+++ b/android/src/main/java/com/filepicker/FilePickerModule.java
@@ -333,6 +333,14 @@ public class FilePickerModule extends ReactContextBaseJavaModule implements Acti
         return null;
     }
 
+     /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    public static boolean isExternalSkydriveResourceUri(Uri uri) {
+        return "com.microsoft.skydrive.content.external".equals(uri.getAuthority());
+    }
+    
     /**
      * @param uri The Uri to check.
      * @return Whether the Uri authority is ExternalStorageProvider.


### PR DESCRIPTION
This adds support for OneDrive via the shortcut options. (as opposed to the default OneDrive link.) Previously, this would yield an error when selecting files.  This has been tested on a Galaxy Tab A.